### PR TITLE
Add optional lepton mass to BtoV to take into account phase-space factor

### DIFF
--- a/effort2/rates/BtoV.py
+++ b/effort2/rates/BtoV.py
@@ -36,7 +36,7 @@ class BtoV:
             Vcb (float): CKM parameter Vcb.
             m_B (float): B meson mass. It is assumed that this value will never change when handling caches.
             m_V (float): V(ector) meson mass. It is assumed that this value will never change when handling caches.
-            m_L (float): Lepton mass. Currently it only limits the kinematic phase-space, i.e. ``self.w_max`` via q²_min = m_L²,
+            m_L (float): Lepton mass. Currently it only limits the kinematic phase-space, i.e. ``self.w_max`` via q2_min = m_L^2,
                          but does not affect the differential decay width via a scalar form-factor.
             G_F (float): Effective coupling constant of the weak interaction (Fermi's constant) in units of GeV^-2. Default value from: https://pdg.lbl.gov/2020/reviews/rpp2020-rev-phys-constants.pdf.
             eta_EW (float): Electroweak corrections.


### PR DESCRIPTION
Allow setting a non-zero lepton mass in the `BtoV` constructor. It only limits the kinematic range (i.e. w_max), a scalar form factor is not yet implemented, but the class documentation is very clear about that.

**Update:** This PR now only includes the addition of a lepton-mass-dependent phase-space factor, which is also considered included in `EvtGen`, see the comment below https://github.com/MarkusPrim/eFFORT2/pull/2#issuecomment-1233322587.

---
### Side-note

One pet-peeve of mine: The attribute `BtoV.mL` does not begin with an underscore and is therefore by convention considered "public". Therefore, before adding the lepton mass to the constructor, I tried setting it manually via e.g.

``` python
rate = BtoV(…)
rate.mL = m_mu
print(rate.w_max)  # is not updated
```
However, setting this doesn't update `BtoV.kinematics` and `BtoV.w_max`. Therefore, I think this attribute is meant to be private, and I would renamed it to `BtoV._mL`. And probably I would do the same for other attributes in the class that are not meant to be set directly. Maybe I should make a separate issue or PR for that, though I understand it's not an urgent TODO item. But I think putting some thought into the class interface would be not bad before going public with eFFORT2.