### PR TITLE
Add `CITATION.cff` and version number

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,10 @@
+cff-version: 1.2.0
+message: "If you use this software, please cite it as below."
+authors:
+  - family-names: Prim
+    given-names: Markus Tobias
+    orcid: https://orcid.org/0000-0002-1407-7450
+title: "eFFORT2"
+version: 0.1.0
+date-released: 2023-08-28
+# doi: 10.5281/zenodo.1234 # TODO: add Zenodo DOI

--- a/effort2/__init__.py
+++ b/effort2/__init__.py
@@ -1,0 +1,1 @@
+__version__ = "0.1.0"  # version should be same as in setup.py and CITATION.cff

--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,5 @@ spectra.
         "License :: OSI Approved :: MIT License "
     ],
     license='MIT',
+    version='0.1.0',  # version should be same as in effort2/__init__.py and CITATION.cff
 )


### PR DESCRIPTION
I want to cite this for my thesis so it would be nice adding a version number, [`CITATION.cff`](https://citation-file-format.github.io) and putting it on Zenodo. I decided to take some work from you by adding the two former things, but the upload to Zenodo you still have to do yourself. Zenodo and github both officially support the `CITATION.cff` format.

After the upload to Zenodo you have to add a `doi=` entry  to the citation file and I if you agree with the version number, you should also tag it in git and/or create it as a release via the github UI.